### PR TITLE
Compare scipy versions using pkg_resources

### DIFF
--- a/SloppyCell/OldScipySupport.py
+++ b/SloppyCell/OldScipySupport.py
@@ -6,7 +6,9 @@ See also addAssignmentRulesToFunctionBody in ReactionNetworks/Network_mod.py
 """
 import scipy
 
-if int(scipy.__version__.split('.')[1]) < 4:
+from pkg_resources import parse_version
+
+if parse_version(scipy.__version__) < parse_version('0.5.1'):
     # Type names have changed
     scipy.float_ = scipy.Float
     scipy.float64 = scipy.Float64


### PR DESCRIPTION
Update OldScipySupport.py to use pkg_resources.parse_version
for comparing scipy versions. Enable workarounds supporting
older versions of scipy only if the version is strictly less
than 0.5.1.